### PR TITLE
Make TypeAliasDeclaration lazy

### DIFF
--- a/packages/@manta-style/runtime/src/index.ts
+++ b/packages/@manta-style/runtime/src/index.ts
@@ -11,6 +11,7 @@ import NeverKeyword from './types/NeverKeyword';
 import StringKeyword from './types/StringKeyword';
 import TypeReference from './types/TypeReference';
 import TypeAliasDeclaration from './nodes/TypeAliasDeclaration';
+import LazyTypeAliasDeclaration from './nodes/LazyTypeAliasDeclaration';
 import ConditionalType from './types/ConditionalType';
 import KeyOfKeyword from './types/KeyOfKeyword';
 import ArrayLiteral from './types/ArrayLiteral';
@@ -141,6 +142,9 @@ class MantaStyle {
   public static ObjectKeyword = new ObjectKeyword();
   public static KeyOfKeyword(type: Type) {
     return new KeyOfKeyword(type);
+  }
+  public static LazyTypeAliasDeclaration(name: string) {
+    return new LazyTypeAliasDeclaration(name);
   }
 }
 

--- a/packages/@manta-style/runtime/src/index.ts
+++ b/packages/@manta-style/runtime/src/index.ts
@@ -80,8 +80,8 @@ class MantaStyle {
     typeCallback: (currentType: TypeAliasDeclaration) => Type,
     annotations: Annotation[],
   ) {
-    const newType = new TypeAliasDeclaration(typeName, annotations);
-    newType.setType(typeCallback(newType));
+    const newType = new LazyTypeAliasDeclaration(typeName, annotations);
+    newType.setInitialize(typeCallback);
     return newType;
   }
   public static TypeLiteral(typeCallback: (currentType: TypeLiteral) => void) {
@@ -142,9 +142,6 @@ class MantaStyle {
   public static ObjectKeyword = new ObjectKeyword();
   public static KeyOfKeyword(type: Type) {
     return new KeyOfKeyword(type);
-  }
-  public static LazyTypeAliasDeclaration(name: string) {
-    return new LazyTypeAliasDeclaration(name);
   }
 }
 

--- a/packages/@manta-style/runtime/src/nodes/LazyTypeAliasDeclaration.ts
+++ b/packages/@manta-style/runtime/src/nodes/LazyTypeAliasDeclaration.ts
@@ -1,44 +1,50 @@
 import TypeAliasDeclaration from './TypeAliasDeclaration';
 import { Type, Annotation } from '../utils/baseType';
 
-export default class LazyTypeAliasDeclaration extends Type {
-  private initializeFn?: () => TypeAliasDeclaration;
-  private typeAliasDeclarationInstance?: TypeAliasDeclaration;
-  private name: string;
-  constructor(name: string) {
-    super();
-    this.name = name;
+export default class LazyTypeAliasDeclaration extends TypeAliasDeclaration {
+  private initializer: (currentType: TypeAliasDeclaration) => Type = () =>
+    this.type;
+  private initialized: boolean;
+
+  constructor(name: string, annotations: Annotation[]) {
+    super(name, annotations);
+    this.initialized = false;
   }
-  public setInitialize(initializeFn: () => TypeAliasDeclaration) {
-    this.initializeFn = initializeFn;
+
+  public setInitialize(
+    initializer: (currentType: TypeAliasDeclaration) => Type,
+  ) {
+    this.initializer = initializer;
   }
-  public initialize(): TypeAliasDeclaration {
-    if (!this.initializeFn) {
-      throw new Error(`${this.name} no initialize fn`);
-    } else if (this.typeAliasDeclarationInstance) {
-      return this.typeAliasDeclarationInstance;
+
+  public initialize() {
+    if (!this.initialized) {
+      this.setType(this.initializer(this));
+      this.initialized = true;
     }
-    return (this.typeAliasDeclarationInstance = this.initializeFn());
-  }
-
-  public deriveLiteral(parentAnnotations: Annotation[]): Type {
-    return this.initialize().deriveLiteral(parentAnnotations);
-  }
-
-  public mock(): any {
-    return this.initialize().mock();
-  }
-
-  public argumentTypes(types: Type[]) {
-    this.initialize().argumentTypes(types);
-    return this;
   }
 
   public getType() {
-    return this.initialize().getType();
+    this.initialize();
+    return super.getType();
   }
 
   public getAnnotations() {
-    return this.initialize().getAnnotations();
+    this.initialize();
+    return super.getAnnotations();
+  }
+
+  public deriveLiteral(parentAnnotations: Annotation[]): Type {
+    this.initialize();
+    return super.deriveLiteral(parentAnnotations);
+  }
+
+  public argumentTypes(types: Type[]) {
+    // need to create a different instance of TypeAliasDeclaration
+    // for each call of argumentTypes(...);
+    const typeAliasImplementation = new TypeAliasDeclaration(this.name, this.annotations);
+    typeAliasImplementation.setType(this.initializer(typeAliasImplementation));
+    typeAliasImplementation.argumentTypes(types);
+    return typeAliasImplementation;
   }
 }

--- a/packages/@manta-style/runtime/src/nodes/LazyTypeAliasDeclaration.ts
+++ b/packages/@manta-style/runtime/src/nodes/LazyTypeAliasDeclaration.ts
@@ -1,0 +1,44 @@
+import TypeAliasDeclaration from './TypeAliasDeclaration';
+import { Type, Annotation } from '../utils/baseType';
+
+export default class LazyTypeAliasDeclaration extends Type {
+  private initializeFn?: () => TypeAliasDeclaration;
+  private typeAliasDeclarationInstance?: TypeAliasDeclaration;
+  private name: string;
+  constructor(name: string) {
+    super();
+    this.name = name;
+  }
+  public setInitialize(initializeFn: () => TypeAliasDeclaration) {
+    this.initializeFn = initializeFn;
+  }
+  public initialize(): TypeAliasDeclaration {
+    if (!this.initializeFn) {
+      throw new Error(`${this.name} no initialize fn`);
+    } else if (this.typeAliasDeclarationInstance) {
+      return this.typeAliasDeclarationInstance;
+    }
+    return (this.typeAliasDeclarationInstance = this.initializeFn());
+  }
+
+  public deriveLiteral(parentAnnotations: Annotation[]): Type {
+    return this.initialize().deriveLiteral(parentAnnotations);
+  }
+
+  public mock(): any {
+    return this.initialize().mock();
+  }
+
+  public argumentTypes(types: Type[]) {
+    this.initialize().argumentTypes(types);
+    return this;
+  }
+
+  public getType() {
+    return this.initialize().getType();
+  }
+
+  public getAnnotations() {
+    return this.initialize().getAnnotations();
+  }
+}

--- a/packages/@manta-style/runtime/src/nodes/TypeAliasDeclaration.ts
+++ b/packages/@manta-style/runtime/src/nodes/TypeAliasDeclaration.ts
@@ -6,13 +6,14 @@ import { resolveReferencedType } from '../utils/referenceTypes';
 import UnionType from '../types/UnionType';
 
 export default class TypeAliasDeclaration extends Type {
-  private readonly name: string;
+  protected readonly name: string;
+  protected readonly annotations: Annotation[];
+
   private typeParameterTypes: Type[] = [];
   private typeParameters: TypeParameter[] = [];
-  private type: Type = new ErrorType(
+  protected type: Type = new ErrorType(
     `TypeAliasDeclaration "${this.name}" hasn't been initialized.`,
   );
-  private readonly annotations: Annotation[];
   constructor(name: string, annotations: Annotation[]) {
     super();
     this.name = name;
@@ -23,7 +24,7 @@ export default class TypeAliasDeclaration extends Type {
     this.typeParameters.push(newTypeParam);
     return newTypeParam;
   }
-  public argumentTypes(types: Type[]) {
+  public argumentTypes(types: Type[]): TypeAliasDeclaration {
     this.typeParameterTypes = types;
     return this;
   }

--- a/packages/@manta-style/runtime/src/utils/referenceTypes.ts
+++ b/packages/@manta-style/runtime/src/utils/referenceTypes.ts
@@ -5,7 +5,6 @@ import TypeParameter from '../nodes/TypeParameter';
 import KeyOfKeyword from '../types/KeyOfKeyword';
 import ParenthesizedType from '../types/ParenthesizedType';
 import { inheritAnnotations } from '../utils/annotation';
-import LazyTypeAliasDeclaration from '../nodes/LazyTypeAliasDeclaration';
 
 /**
  * @description
@@ -24,14 +23,14 @@ export function resolveReferencedType(
     actualType instanceof TypeAliasDeclaration ||
     actualType instanceof TypeParameter ||
     actualType instanceof ParenthesizedType ||
-    actualType instanceof KeyOfKeyword ||
-    actualType instanceof LazyTypeAliasDeclaration
+    actualType instanceof KeyOfKeyword
   ) {
-    if (actualType instanceof LazyTypeAliasDeclaration) {
-      actualType = actualType.initialize();
-    } else if (actualType instanceof TypeReference) {
+    if (actualType instanceof TypeReference) {
       actualType = actualType.getActualType();
     } else if (actualType instanceof TypeAliasDeclaration) {
+      // Make sure type parameters has been initialized
+      // as we moved the initialization from `argumentTypes`
+      // to `deriveLiteral`.
       actualType.deriveLiteral(annotations);
       annotations = inheritAnnotations(
         annotations,

--- a/packages/@manta-style/runtime/src/utils/referenceTypes.ts
+++ b/packages/@manta-style/runtime/src/utils/referenceTypes.ts
@@ -5,6 +5,7 @@ import TypeParameter from '../nodes/TypeParameter';
 import KeyOfKeyword from '../types/KeyOfKeyword';
 import ParenthesizedType from '../types/ParenthesizedType';
 import { inheritAnnotations } from '../utils/annotation';
+import LazyTypeAliasDeclaration from '../nodes/LazyTypeAliasDeclaration';
 
 /**
  * @description
@@ -23,14 +24,14 @@ export function resolveReferencedType(
     actualType instanceof TypeAliasDeclaration ||
     actualType instanceof TypeParameter ||
     actualType instanceof ParenthesizedType ||
-    actualType instanceof KeyOfKeyword
+    actualType instanceof KeyOfKeyword ||
+    actualType instanceof LazyTypeAliasDeclaration
   ) {
-    if (actualType instanceof TypeReference) {
+    if (actualType instanceof LazyTypeAliasDeclaration) {
+      actualType = actualType.initialize();
+    } else if (actualType instanceof TypeReference) {
       actualType = actualType.getActualType();
     } else if (actualType instanceof TypeAliasDeclaration) {
-      // Make sure type parameters has been initialized
-      // as we moved the initialization from `argumentTypes`
-      // to `deriveLiteral`.
       actualType.deriveLiteral(annotations);
       annotations = inheritAnnotations(
         annotations,

--- a/packages/@manta-style/typescript-transformer/src/constants.ts
+++ b/packages/@manta-style/typescript-transformer/src/constants.ts
@@ -1,3 +1,15 @@
 export const MANTASTYLE_RUNTIME_NAME = 'MantaStyle';
+export const MANTASTYLE_HELPER_NAME = 'MantaStyleHelper';
 export const MANTASTYLE_PACKAGE_NAME = '@manta-style/runtime';
 export const HELPER_PACKAGE_NAME = '@manta-style/typescript-helpers';
+
+export const MANTASTYLE_HELPER_TYPES = [
+  'Partial',
+  'Required',
+  'Readonly',
+  'Pick',
+  'Record',
+  'Exclude',
+  'Extract',
+  'NonNullable',
+];

--- a/packages/@manta-style/typescript-transformer/src/utils.ts
+++ b/packages/@manta-style/typescript-transformer/src/utils.ts
@@ -1,5 +1,9 @@
 import * as ts from 'typescript';
-import { MANTASTYLE_RUNTIME_NAME } from './constants';
+import {
+  MANTASTYLE_RUNTIME_NAME,
+  MANTASTYLE_HELPER_NAME,
+  MANTASTYLE_HELPER_TYPES,
+} from './constants';
 import { isOptionalTypeNode, isRestTypeNode } from './typescript';
 import { QuestionToken, ReservedTypePrefix } from '@manta-style/consts';
 
@@ -38,63 +42,48 @@ export function createTypeAliasDeclaration(node: ts.TypeAliasDeclaration) {
   const name = node.name.getText();
   const typeParameters = node.typeParameters || ts.createNodeArray();
   const jsdocTags = ts.getJSDocTags(node);
+
   const varCreation = createConstVariableStatement(
     name,
-    ts.createFunctionExpression(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      [],
-      undefined,
-      ts.createBlock([
-        ts.createReturn(
-          createRuntimeFunctionCall('TypeAliasDeclaration', [
-            ts.createStringLiteral(name),
-            ts.createArrowFunction(
-              undefined,
-              undefined,
-              [
-                ts.createParameter(
-                  undefined,
-                  undefined,
-                  undefined,
-                  'typeFactory',
-                  undefined,
-                  undefined,
-                  undefined,
-                ),
-              ],
-              undefined,
-              undefined,
-              ts.createBlock(
-                [
-                  ...createTypeParameters(
-                    typeParameters,
-                    typeParameters,
-                    'typeFactory',
-                  ),
-                  createConstVariableStatement(
-                    'type',
-                    createMantaStyleRuntimeObject(node.type, typeParameters),
-                  ),
-                  ts.createReturn(ts.createIdentifier('type')),
-                ],
-                true,
-              ),
+    createRuntimeFunctionCall('TypeAliasDeclaration', [
+      ts.createStringLiteral(name),
+      ts.createArrowFunction(
+        undefined,
+        undefined,
+        [
+          ts.createParameter(
+            undefined,
+            undefined,
+            undefined,
+            'typeFactory',
+            undefined,
+            undefined,
+            undefined,
+          ),
+        ],
+        undefined,
+        undefined,
+        ts.createBlock(
+          [
+            ...createTypeParameters(
+              typeParameters,
+              typeParameters,
+              'typeFactory',
             ),
-            generateJSDocParam(jsdocTags),
-          ]),
+            createConstVariableStatement(
+              'type',
+              createMantaStyleRuntimeObject(node.type, typeParameters),
+            ),
+            ts.createReturn(ts.createIdentifier('type')),
+          ],
+          true,
         ),
-      ]),
-    ),
+      ),
+      generateJSDocParam(jsdocTags),
+    ]),
   );
-  const registerToRuntime = createRuntimeFunctionCall('registerType', [
-    ts.createStringLiteral(name),
-    ts.createIdentifier(name),
-  ]);
   varCreation.modifiers = node.modifiers;
-  return [varCreation, registerToRuntime];
+  return varCreation;
 }
 
 export function createRuntimeFunctionCall(
@@ -433,11 +422,17 @@ function createTypeReference(
       throw Error('key in unstable_Query is not a string literal.');
     }
   }
-  const typeReferenceNode = isGenericTypeReference(typeName, typeParameters)
-    ? ts.createIdentifier(typeName)
-    : createRuntimeFunctionCall('TypeReference', [
-        ts.createStringLiteral(typeName),
-      ]);
+
+  let typeReferenceNode;
+  if (MANTASTYLE_HELPER_TYPES.indexOf(typeName) > -1) {
+    typeReferenceNode = ts.createPropertyAccess(
+      ts.createIdentifier(MANTASTYLE_HELPER_NAME),
+      ts.createIdentifier(typeName),
+    );
+  } else {
+    typeReferenceNode = ts.createIdentifier(typeName);
+  }
+
   if (node.typeArguments) {
     return ts.createCall(
       ts.createPropertyAccess(typeReferenceNode, 'argumentTypes'),


### PR DESCRIPTION
Issue #1 

now `TypeAliasDeclaration` get transformed into 

```
const UserInfo = MantaStyle.TypeAliasDeclaration(
  "UserInfo",
  typeFactory => {
    return MantaStyle.TypeLiteral(...)
  },
  [],
)
```

the typeFactoryCallback is lazily called only when `deriveLiteral` or `getType` is being called.

For typescript built-in types, will be imported as just like normal TypeAliasDeclaration from `typescript-helpers`, eg:
```
import * as MantaStyleHelper from '@manta-style/typescript-helpers'
...
// somewhere in the code
MantaStyleHelper.Exclude(...)
```